### PR TITLE
whitelist chat.ocf.berkeley.edu

### DIFF
--- a/kubernetes/secrets/synapse-config/homeserver.yaml.erb
+++ b/kubernetes/secrets/synapse-config/homeserver.yaml.erb
@@ -83,6 +83,10 @@ saml2_config:
       remote:
         - url: https://auth.ocf.berkeley.edu/auth/realms/ocf/protocol/saml/descriptor
 
+sso:
+  client_whitelist:
+    - "https://chat.ocf.berkeley.edu/"
+
 password_config:
   enabled: false
 


### PR DESCRIPTION
this avoid the "make sure you trust this client" or whatever screen

needs to be tested