### PR TITLE
set IRC client limit to 4000

### DIFF
--- a/kubernetes/secrets/bridge-config/config.yaml.erb
+++ b/kubernetes/secrets/bridge-config/config.yaml.erb
@@ -102,7 +102,7 @@ ircService:
       ircClients:
         nickTemplate: "$DISPLAY[m]"
         allowNickChanges: true
-        maxClients: 400
+        maxClients: 4000
         ipv6:
           only: false
         idleTimeout: 1814400


### PR DESCRIPTION
there are too many clients on matrix and discord, need to bump the limits for IRC connections