### PR TITLE
Revert "[Automatic] Update element from 1.7.33 to 1.8.2."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BRIDGE_DOCKER_TAG = docker-push.ocf.berkeley.edu/matrix-appservice-irc:$(DOCKER_
 RIOT_DOCKER_TAG = docker-push.ocf.berkeley.edu/riot:$(DOCKER_REVISION)
 
 SYNAPSE_VERSION := v1.41.1
-RIOT_VERSION := v1.8.2
+RIOT_VERSION := v1.7.33
 BRIDGE_VERSION := release-0.30.0
 
 .PHONY: cook-image


### PR DESCRIPTION
Reverts ocf/matrix#137

the docker images are seemingly unmaintained (no new images in 2 months), so we're stuck on 1.7.33 until this is fixed