### PR TITLE
Revert "[Automatic] Update synapse from 1.48.0 to 1.53.0."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SYNAPSE_DOCKER_TAG = docker-push.ocf.berkeley.edu/synapse:$(DOCKER_REVISION)
 BRIDGE_DOCKER_TAG = docker-push.ocf.berkeley.edu/matrix-appservice-irc:$(DOCKER_REVISION)
 RIOT_DOCKER_TAG = docker-push.ocf.berkeley.edu/riot:$(DOCKER_REVISION)
 
-SYNAPSE_VERSION := v1.53.0
+SYNAPSE_VERSION := v1.48.0
 RIOT_VERSION := v1.9.3
 BRIDGE_VERSION := release-0.23.0
 


### PR DESCRIPTION
We can update to 1.49 but 1.50 requires Postgres >=10 (https://github.com/matrix-org/synapse/pull/11725)


Reverts ocf/matrix#176