### PR TITLE
Bump IRC bridge to 0.34.0 (high severity vulnerability)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RIOT_DOCKER_TAG = docker-push.ocf.berkeley.edu/riot:$(DOCKER_REVISION)
 
 SYNAPSE_VERSION := v1.57.1
 RIOT_VERSION := v1.10.10
-BRIDGE_VERSION := release-0.23.0
+BRIDGE_VERSION := release-0.34.0
 
 .PHONY: cook-image
 cook-image:


### PR DESCRIPTION
https://matrix.org/blog/2022/05/04/0-34-0-security-release-for-matrix-appservice-irc-high-severity

I checked and there aren't any breaking changes from 0.23 to 0.34.