### PR TITLE
switch back to upstream container images

### DIFF
--- a/kubernetes/discord.yml.erb
+++ b/kubernetes/discord.yml.erb
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: discord-appservice-irc
-          image: "ocfrjz/matrix-appservice-discord:latest"
+          image: "ghcr.io/matrix-org/matrix-appservice-discord:develop"
           imagePullPolicy: Always
           ports:
             - containerPort: 9005


### PR DESCRIPTION
Upstream recently added automated image builds, so switch back.

Also, stay on rolling `develop` tag instead of a tagged version since we don't have Adelie set up for this yet...

*Also*, the bridge is currently broken right now but this doesn't fix it :(