### PR TITLE
Fix Discord appservice namespace

### DIFF
--- a/kubernetes/secrets/discord-config/discord-registration.yaml.erb
+++ b/kubernetes/secrets/discord-config/discord-registration.yaml.erb
@@ -4,10 +4,10 @@ id: <%= discord_id %>
 namespaces:
   aliases:
     - exclusive: true
-      regex: '#_discord_.*'
+      regex: '#_discord_.*?:ocf\.berkeley\.edu'
   users:
     - exclusive: true
-      regex: '@_discord_.*'
+      regex: '@_discord_.*?:ocf\.berkeley\.edu'
 protocols:
   - discord
 rate_limited: false


### PR DESCRIPTION
It's currently expanding to any homeserver, which is causing errors since those users aren't registered with our appservice because they are federated.