### PR TITLE
Use forked Discord appservice image

### DIFF
--- a/kubernetes/discord.yml.erb
+++ b/kubernetes/discord.yml.erb
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: discord-appservice-irc
-          image: "ghcr.io/matrix-org/matrix-appservice-discord:develop"
+          image: "ghcr.io/kalissaac/matrix-appservice-discord:develop"
           imagePullPolicy: Always
           ports:
             - containerPort: 9005


### PR DESCRIPTION
Until we ship the changes upstream, use the forked image which fixes the following issues:

- Discord -> Matrix messages not relaying
- "&apos;" in messages