### PR TITLE
Fix Discord namespace regex (again)

### DIFF
--- a/kubernetes/secrets/discord-config/discord-registration.yaml.erb
+++ b/kubernetes/secrets/discord-config/discord-registration.yaml.erb
@@ -4,10 +4,10 @@ id: <%= discord_id %>
 namespaces:
   aliases:
     - exclusive: true
-      regex: '#_discord_.*?:ocf\.berkeley\.edu'
+      regex: '#_discord_.*:ocf\.berkeley\.edu'
   users:
     - exclusive: true
-      regex: '@_discord_.*?:ocf\.berkeley\.edu'
+      regex: '@_discord_.*:ocf\.berkeley\.edu'
 protocols:
   - discord
 rate_limited: false


### PR DESCRIPTION
The appservice didn't like the `.*?` because it trims two characters off the end of the string, not three.